### PR TITLE
Add final-project note to readme

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/readme.md
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/readme.md
@@ -129,3 +129,7 @@ Note: Some names start with "Team" and others start with "team".  This is intent
 5)  Add:    include ':Team0417' to the "/settings.gradle" file.
     
 6)  Open up Android Studios and clean out any old files by using the menu to "Build/Clean Project""
+
+
+This is the last state of the project for the 2025/6 ftc season codebase, but the first 
+commit for the Crawler library!


### PR DESCRIPTION
Append a short note to TeamCode/src/main/java/org/firstinspires/ftc/teamcode/readme.md indicating this is the last state of the project for the 2025/6 FTC season and the first commit for the Crawler library. Also adds minor trailing newlines/spacing to the file.

Before issuing a pull request, please see the contributing page.
